### PR TITLE
Problem: X-Up-Location content

### DIFF
--- a/lib/unpoly.ex
+++ b/lib/unpoly.ex
@@ -149,7 +149,7 @@ defmodule Unpoly do
 
   defp echo_request_headers(conn) do
     conn
-    |> put_resp_location_header(Phoenix.Controller.current_url(conn))
+    |> put_resp_location_header(Plug.Conn.request_url(conn))
     |> put_resp_method_header(conn.method)
   end
 

--- a/test/unpoly_test.exs
+++ b/test/unpoly_test.exs
@@ -55,7 +55,7 @@ defmodule UnpolyTest do
         build_conn_for_path("/foo")
         |> Unpoly.call(Unpoly.init([]))
 
-      assert ["https://www.example.com/foo"] = get_resp_header(conn, "x-up-location")
+      assert ["http://www.example.com/foo"] = get_resp_header(conn, "x-up-location")
       assert ["GET"] = get_resp_header(conn, "x-up-method")
     end
 
@@ -64,7 +64,7 @@ defmodule UnpolyTest do
         build_conn_for_path("/foo?bar=baz")
         |> Unpoly.call(Unpoly.init([]))
 
-      assert ["https://www.example.com/foo?bar=baz"] = get_resp_header(conn, "x-up-location")
+      assert ["http://www.example.com/foo?bar=baz"] = get_resp_header(conn, "x-up-location")
       assert ["GET"] = get_resp_header(conn, "x-up-method")
     end
 


### PR DESCRIPTION
ex_unpoly serves it with the hostname included.

I ran into a problem. After I plugged in ex_unpoly, my Unpoly
transitions stopped working. I noticed that the X-Up-Location response
header served contained a full URL (with the hostname set to localhost,
even though I was accessing it remotely from a different machine).

Solution: include only the path

https://unpoly.com/up.protocol suggests that the host is not necessary.